### PR TITLE
Removed table and column existence check from MissingObjectAnalyzer #68

### DIFF
--- a/docs/diagnostics/AJ5044.md
+++ b/docs/diagnostics/AJ5044.md
@@ -17,11 +17,11 @@
   </tr>
   <tr>
     <td class="header"><b>Message Template</b></td>
-    <td>The referenced {0} `{1}` was not found.</td>
+    <td>The referenced `{0}` `{1}` was not found.</td>
   </tr>
     <tr>
     <td class="header"><b>Insertion string {0}</b></td>
-    <td>Object type name</td>
+    <td>Object Type Name</td>
   </tr>
   <tr>
     <td class="header"><b>Insertion string {1}</b></td>

--- a/src/src/DatabaseAnalyzers.DefaultAnalyzers.Tests/Analyzers/Runtime/MissingObjectAnalyzerTests.cs
+++ b/src/src/DatabaseAnalyzers.DefaultAnalyzers.Tests/Analyzers/Runtime/MissingObjectAnalyzerTests.cs
@@ -14,11 +14,6 @@ public sealed class MissingObjectAnalyzerTests(ITestOutputHelper testOutputHelpe
 
                                       CREATE PROCEDURE  schema1.P1 AS BEGIN PRINT 303 END
                                       GO
-
-                                      CREATE FUNCTION   schema1.F1 () RETURNS INT AS BEGIN RETURN 1 END
-                                      GO
-
-                                      CREATE TABLE      schema1.T1 (Id INT, Column1 INT)
                                       """;
 
     private static readonly Aj5044Settings Settings = new Aj5044SettingsRaw
@@ -104,81 +99,5 @@ public sealed class MissingObjectAnalyzerTests(ITestOutputHelper testOutputHelpe
                             """;
 
         Verify(Settings, code, SharedCode);
-    }
-
-    [Theory]
-    [InlineData(" /* 0000 */ DB1.schema1.T1                                                     ")]
-    [InlineData(" /* 0001 */ DB1.ignored.T1                                                     ")]
-    [InlineData(" /* 0002 */ ▶️AJ5044💛script_0.sql💛💛table💛xxx.schema1.T1✅xxx.schema1.T1◀️       ")]
-    [InlineData(" /* 0003 */ ▶️AJ5044💛script_0.sql💛💛table💛DB1.xxx.T1✅DB1.xxx.T1◀️               ")]
-    [InlineData(" /* 0004 */ ▶️AJ5044💛script_0.sql💛💛table💛DB1.schema1.xxx✅DB1.schema1.xxx◀️     ")]
-    public void TableReference_Theory(string tableNameCode)
-    {
-        var code = $"""
-                    USE MyDb
-                    GO
-
-                    SELECT * FROM {tableNameCode}
-
-                    """;
-
-        Verify(Settings, code, SharedCode);
-    }
-
-    [Theory]
-    [InlineData(" /* 0000 */ Column1                                                ")]
-    [InlineData(" /* 0001 */ ▶️AJ5044💛script_0.sql💛💛column💛DB1.schema1.T1.xxx✅xxx◀️ ")]
-    public void ColumnReferenceOnExistingTable_Theory(string columnNameCode)
-    {
-        var code = $"""
-                    USE MyDb
-                    GO
-
-                    SELECT {columnNameCode} FROM DB1.schema1.T1
-
-                    """;
-
-        Verify(Settings, code, SharedCode);
-    }
-
-    [Fact]
-    public void WhenSelectingFromTempTable_ThenOk()
-    {
-        const string code = """
-                            USE MyDb
-                            GO
-
-                            CREATE TABLE #T
-                            (
-                                Id      INT
-                            )
-
-                            SELECT Bla FROM #T
-                            """;
-
-        Verify(Settings, code, SharedCode);
-    }
-
-    [Fact]
-    public void WhenSelectingFromCte_ThenOk()
-    {
-        const string code = """
-                            USE Db1
-                            GO
-
-                            CREATE TABLE      schema1.T1 (Id INT, Column1 INT)
-                            GO
-
-                            WITH MyCTE AS
-                            (
-                                SELECT  Column1
-                                FROM    DB1.schema1.T1
-                            )
-
-                            SELECT      DoesNotExist
-                            FROM        MyCTE;
-                            """;
-
-        Verify(Settings, code);
     }
 }

--- a/src/src/DatabaseAnalyzers.DefaultAnalyzers/Analyzers/Runtime/MissingObjectAnalyzer.cs
+++ b/src/src/DatabaseAnalyzers.DefaultAnalyzers/Analyzers/Runtime/MissingObjectAnalyzer.cs
@@ -1,8 +1,5 @@
-using System.Collections.Frozen;
 using System.Diagnostics.CodeAnalysis;
 using DatabaseAnalyzer.Common.Extensions;
-using DatabaseAnalyzer.Common.Services;
-using DatabaseAnalyzer.Common.SqlParsing;
 using DatabaseAnalyzer.Common.SqlParsing.Extraction;
 using DatabaseAnalyzer.Common.SqlParsing.Extraction.Models;
 using DatabaseAnalyzer.Contracts;
@@ -22,120 +19,7 @@ public sealed class MissingObjectAnalyzer : IGlobalAnalyzer
         var databasesByName = new DatabaseObjectExtractor(context.IssueReporter)
             .Extract(context.Scripts, context.DefaultSchemaName);
 
-        var cteNamesByBatch = context.Scripts
-            .SelectMany(a => a.ParsedScript.Batches)
-            .ToDictionary(a => a, CteExtractor.ExtractCteNames);
-
-        var cteBatchInformationProvider = new CteBatchInformationProvider(cteNamesByBatch);
-
         AnalyzeProcedureCalls(context, settings, databasesByName);
-        AnalyzeTableReferences(context, settings, databasesByName, cteBatchInformationProvider);
-        AnalyzeColumnReferences(context, settings, databasesByName, cteBatchInformationProvider);
-    }
-
-    private static void AnalyzeColumnReferences(IAnalysisContext context, Aj5044Settings settings, IReadOnlyDictionary<string, DatabaseInformation> databasesByName, CteBatchInformationProvider cteBatchInformationProvider)
-    {
-        var columnReferencesAndScripts = context.Scripts
-            .SelectMany(a => a
-                .ParsedScript
-                .GetChildren<ColumnReferenceExpression>(recursive: true)
-                .Select(b => (ColumnReference: b, Script: a))
-            );
-
-        foreach (var (columnReference, script) in columnReferencesAndScripts)
-        {
-            AnalyzeColumnReference(context, settings, databasesByName, script, columnReference, cteBatchInformationProvider);
-        }
-    }
-
-    private static void AnalyzeColumnReference(IAnalysisContext context, Aj5044Settings settings, IReadOnlyDictionary<string, DatabaseInformation> databasesByName, IScriptModel script, ColumnReferenceExpression columnReference, CteBatchInformationProvider cteBatchInformationProvider)
-    {
-        var resolver = new TableColumnResolver(new IssueReporter(), script.ParsedScript, script.RelativeScriptFilePath, script.ParentFragmentProvider, context.DefaultSchemaName);
-        var column = resolver.Resolve(columnReference);
-        if (column is null)
-        {
-            return;
-        }
-
-        if (column.TableName.IsTempTableName())
-        {
-            return;
-        }
-
-        var batch = script.ParentFragmentProvider.GetParents(columnReference).OfType<TSqlBatch>().FirstOrDefault();
-        if (batch is not null)
-        {
-            if (cteBatchInformationProvider.IsCte(batch, column.TableName))
-            {
-                return;
-            }
-        }
-
-        if (DoesTableColumnOrViewColumnExist(databasesByName, column.DatabaseName, column.SchemaName, column.TableName, column.ColumnName))
-        {
-            return;
-        }
-
-        if (IsIgnored(settings, column.FullName))
-        {
-            return;
-        }
-
-        var databaseName = script.ParsedScript.TryFindCurrentDatabaseNameAtFragment(columnReference) ?? DatabaseNames.Unknown;
-        var fullObjectName = columnReference.TryGetFirstClassObjectName(context, script);
-        context.IssueReporter.Report(DiagnosticDefinitions.Default, databaseName, script.RelativeScriptFilePath, fullObjectName, columnReference.GetCodeRegion(), "column", column.FullName);
-    }
-
-    private static void AnalyzeTableReferences(IAnalysisContext context, Aj5044Settings settings, IReadOnlyDictionary<string, DatabaseInformation> databasesByName, CteBatchInformationProvider cteBatchInformationProvider)
-    {
-        var namedTableReferencesAndScripts = context.Scripts
-            .SelectMany(a => a
-                .ParsedScript
-                .GetChildren<NamedTableReference>(recursive: true)
-                .Select(b => (NamedTableReference: b, Script: a))
-            );
-
-        foreach (var (tableReference, script) in namedTableReferencesAndScripts)
-        {
-            AnalyzeTableReference(context, settings, databasesByName, script, tableReference, cteBatchInformationProvider);
-        }
-    }
-
-    private static void AnalyzeTableReference(IAnalysisContext context, Aj5044Settings settings, IReadOnlyDictionary<string, DatabaseInformation> databasesByName, IScriptModel script, NamedTableReference tableReference, CteBatchInformationProvider cteBatchInformationProvider)
-    {
-        var tableName = tableReference.SchemaObject.BaseIdentifier.Value;
-        if (tableName.IsTempTableName())
-        {
-            return;
-        }
-
-        var batch = script.ParentFragmentProvider.GetParents(tableReference).OfType<TSqlBatch>().FirstOrDefault();
-        if (batch is not null)
-        {
-            if (cteBatchInformationProvider.IsCte(batch, tableReference.SchemaObject.BaseIdentifier.Value))
-            {
-                return;
-            }
-        }
-
-        var schemaName = tableReference.SchemaObject.SchemaIdentifier?.Value.NullIfEmptyOrWhiteSpace() ?? context.DefaultSchemaName;
-        var databaseName = tableReference.SchemaObject.DatabaseIdentifier?.Value.NullIfEmptyOrWhiteSpace()
-                           ?? script.ParsedScript.TryFindCurrentDatabaseNameAtFragment(tableReference)
-                           ?? DatabaseNames.Unknown;
-
-        if (DoesTableOrViewExist(databasesByName, databaseName, schemaName, tableName))
-        {
-            return;
-        }
-
-        var fullTableName = $"{databaseName}.{schemaName}.{tableName}";
-        if (IsIgnored(settings, fullTableName))
-        {
-            return;
-        }
-
-        var fullObjectName = tableReference.TryGetFirstClassObjectName(context, script);
-        context.IssueReporter.Report(DiagnosticDefinitions.Default, databaseName, script.RelativeScriptFilePath, fullObjectName, tableReference.GetCodeRegion(), "table", fullTableName);
     }
 
     private static void AnalyzeProcedureCalls(IAnalysisContext context, Aj5044Settings settings, IReadOnlyDictionary<string, DatabaseInformation> databasesByName)
@@ -198,82 +82,8 @@ public sealed class MissingObjectAnalyzer : IGlobalAnalyzer
         context.IssueReporter.Report(DiagnosticDefinitions.Default, databaseName, callingProcedure.RelativeScriptFilePath, callingProcedure.FullName, procedureObjectName.GetCodeRegion(), "procedure", calledProcedureName);
     }
 
-    private static bool DoesTableColumnOrViewColumnExist(IReadOnlyDictionary<string, DatabaseInformation> databasesByName, string databaseName, string schemaName, string tableOrViewName, string columnName)
-    {
-        var schema = databasesByName.GetValueOrDefault(databaseName)?.SchemasByName.GetValueOrDefault(schemaName);
-        if (schema is null)
-        {
-            return false;
-        }
-
-        var table = schema.TablesByName.GetValueOrDefault(tableOrViewName);
-        if (table is not null)
-        {
-            if (table.Columns.Any(a => columnName.EqualsOrdinalIgnoreCase(a.ObjectName)))
-            {
-                return true;
-            }
-        }
-
-        var view = schema.ViewsByName.GetValueOrDefault(tableOrViewName);
-        if (view is not null)
-        {
-            if (view.Columns.Any(columnName.EqualsOrdinalIgnoreCase))
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private static bool DoesTableOrViewExist(IReadOnlyDictionary<string, DatabaseInformation> databasesByName, string databaseName, string schemaName, string tableOrViewName)
-    {
-        var schema = databasesByName.GetValueOrDefault(databaseName)?.SchemasByName.GetValueOrDefault(schemaName);
-        if (schema is null)
-        {
-            return false;
-        }
-
-        return schema.TablesByName.ContainsKey(tableOrViewName) || schema.ViewsByName.ContainsKey(tableOrViewName);
-    }
-
     private static bool IsIgnored(Aj5044Settings settings, string procedureName)
         => settings.IgnoredObjectNamePatterns.Any(a => a.IsMatch(procedureName));
-
-    private sealed class IssueReporter : IIssueReporter
-    {
-        public void Report(IDiagnosticDefinition rule, string databaseName, string relativeScriptFilePath, string? fullObjectName, CodeRegion codeRegion, params object[] insertionStrings)
-        {
-        }
-
-        public IReadOnlyList<IIssue> Issues => [];
-    }
-
-    private sealed class CteBatchInformationProvider
-    {
-        private readonly IReadOnlyDictionary<TSqlBatch, FrozenSet<string>> _cteNamesByBatch;
-
-        public CteBatchInformationProvider(IReadOnlyDictionary<TSqlBatch, FrozenSet<string>> cteNamesByBatch)
-        {
-            _cteNamesByBatch = cteNamesByBatch;
-        }
-
-        public bool IsCte(TSqlBatch? batch, string? tableName)
-        {
-            if (batch is null || tableName.IsNullOrWhiteSpace())
-            {
-                return false;
-            }
-
-            if (!_cteNamesByBatch.TryGetValue(batch, out var cteNames))
-            {
-                return false;
-            }
-
-            return cteNames.Contains(tableName);
-        }
-    }
 
     private static class DiagnosticDefinitions
     {
@@ -282,8 +92,8 @@ public sealed class MissingObjectAnalyzer : IGlobalAnalyzer
             "AJ5044",
             IssueType.Warning,
             "Missing Object",
-            "The referenced {0} `{1}` was not found.",
-            ["Object type name", "Expression"],
+            "The referenced `{0}` `{1}` was not found.",
+            ["Object Type Name", "Expression"],
             UrlPatterns.DefaultDiagnosticHelp
         );
     }


### PR DESCRIPTION
Since Update statements with aliases etc. make things very complicated, checks for missing tables or columns have been removed completely.

Commit which still contains this code is: e5d3bfc0deb49ac9c488be1aa4f9c38be7ea4ec8