### PR TITLE
AJ5051 fix: If an indexed foreign key column is not used as filter predicate, the issue is raised

### DIFF
--- a/src/DatabaseAnalyzers.DefaultAnalyzers.Tests/Analyzers/Indices/UnusedIndexAnalyzerTests.cs
+++ b/src/DatabaseAnalyzers.DefaultAnalyzers.Tests/Analyzers/Indices/UnusedIndexAnalyzerTests.cs
@@ -132,24 +132,24 @@ public sealed class UnusedIndexAnalyzerTests(ITestOutputHelper testOutputHelper)
                             USE MyDb
                             GO
 
-                            CREATE TABLE A
+                            CREATE TABLE Genre
                             (
                                 Id                  INT NOT NULL PRIMARY KEY,
-                                OtherId             NVARCHAR(250) NOT NULL
+                                Name                NVARCHAR(250) NOT NULL
                             )
                             GO
 
-                            CREATE TABLE B
+                            CREATE TABLE Book
                             (
                                 Id                  INT NOT NULL PRIMARY KEY,
-                                OtherIdFromTableA   INT NOT NULL,
-                                CONSTRAINT          [FK_B_A] FOREIGN KEY( [OtherIdFromTableA]) REFERENCES [dbo].[A] ([OtherId])
+                                GenreId             INT NOT NULL,
+                                CONSTRAINT          [FK_Book_Genre] FOREIGN KEY( [GenreId]) REFERENCES [dbo].[Genre] ([Id])
                             )
                             GO
 
-                            CREATE NONCLUSTERED INDEX [IX_B_OtherIdFromTableA] ON [dbo].[B]
+                            CREATE NONCLUSTERED INDEX [IX_Book_GenreId] ON [dbo].[Book]
                             (
-                                [OtherIdFromTableA] ASC
+                                [GenreId] ASC
                             )
                             GO
 
@@ -157,7 +157,7 @@ public sealed class UnusedIndexAnalyzerTests(ITestOutputHelper testOutputHelper)
                             AS
                             BEGIN
                                 SELECT    *
-                                FROM      dbo.B
+                                FROM      dbo.Book
                             END
                             """;
 

--- a/src/DatabaseAnalyzers.DefaultAnalyzers/Analyzers/Indices/UnusedIndexAnalyzer.cs
+++ b/src/DatabaseAnalyzers.DefaultAnalyzers/Analyzers/Indices/UnusedIndexAnalyzer.cs
@@ -61,7 +61,12 @@ public sealed class UnusedIndexAnalyzer : IGlobalAnalyzer
                 }
 
                 var table = _objectProvider.GetTable(index.DatabaseName, index.SchemaName, index.TableName);
-                if (table?.ForeignKeysByColumnName.ContainsKey(columnName) == true)
+                if (table is null)
+                {
+                    continue;
+                }
+
+                if (table.ForeignKeysByColumnName.ContainsKey(columnName))
                 {
                     continue;
                 }


### PR DESCRIPTION
Not able to reproduce the issue #398. However, this MR contains a small bugfix that might solve the issue